### PR TITLE
Support jku & jwk in header

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -12,6 +12,7 @@ config :guardian, Guardian,
       verify_issuer: true,
       secret_key: "woiuerojksldkjoierwoiejrlskjdf",
       serializer: Guardian.TestGuardianSerializer,
+      jku_agent: Guardian.TestJKUAgent,
       hooks: Guardian.Hooks.Test,
       system_foo: {:system, "FOO"},
       permissions: %{

--- a/lib/guardian/jku_agent.ex
+++ b/lib/guardian/jku_agent.ex
@@ -1,0 +1,12 @@
+defmodule Guardian.JKUAgent do
+  @moduledoc """
+  Guardian JKU fetch behaviour.
+
+  Guardian uses this if provided to retrieve the JWK specified by jku. This can be internally cached if needed.
+  """
+
+  @doc """
+  Retrieves the JWK specified by the jku.
+  """
+  @callback get(kid :: String.t, uri :: String.t) :: {:ok, object :: term} | {:error, String.t}
+end

--- a/mix.exs
+++ b/mix.exs
@@ -47,14 +47,14 @@ defmodule Guardian.Mixfile do
      {:plug, "~> 1.3"},
      {:poison, ">= 1.3.0"},
      {:uuid, ">=1.1.1"},
-     {:hackney, "~> 1.8"},
 
      # Dev and Test dependencies
      {:mock, "~> 0.2", only: :test},
      {:credo, "~> 0.6.1", only: [:dev, :test]},
      {:dialyxir, "~> 0.4.3", only: [:dev, :test]},
      {:earmark, ">= 0.0.0", only: :dev},
-     {:ex_doc, "~> 0.12", only: :dev}]
+     {:ex_doc, "~> 0.12", only: :dev},
+     {:hackney, "~> 1.8", only: [:test]}]
   end
 
   defp package do

--- a/test/guardian_test.exs
+++ b/test/guardian_test.exs
@@ -45,6 +45,12 @@ defmodule GuardianTest do
       "kid" => "abcd"
     })
 
+    {_header, es512_jose_jwk_map} = JOSE.JWK.to_map(es512_jose_jwk)
+    es512_jose_jws_with_valid_jwk = JOSE.JWS.from_map(%{
+      "alg" => "ES512",
+      "jwk" => es512_jose_jwk_map
+    })
+
     es512_jose_jwt_with_valid_jku = es512_jose_jwk
       |> JOSE.JWT.sign(es512_jose_jws_with_valid_jku, claims)
       |> JOSE.JWS.compact
@@ -52,6 +58,11 @@ defmodule GuardianTest do
 
     es512_jose_jwt_with_invalid_jku = es512_jose_jwk
       |> JOSE.JWT.sign(es512_jose_jws_with_invalid_jku, claims)
+      |> JOSE.JWS.compact
+      |> elem(1)
+
+    es512_jose_jwt_with_valid_jwk = es512_jose_jwk
+      |> JOSE.JWT.sign(es512_jose_jws_with_valid_jwk, claims)
       |> JOSE.JWS.compact
       |> elem(1)
 
@@ -84,6 +95,7 @@ defmodule GuardianTest do
           jwt: es512_jose_jwt,
           jwt_with_valid_jku: es512_jose_jwt_with_valid_jku,
           jwt_with_invalid_jku: es512_jose_jwt_with_invalid_jku,
+          jwt_with_valid_jwk: es512_jose_jwt_with_valid_jwk,
           mocks: mocks
         }
       }
@@ -154,6 +166,10 @@ defmodule GuardianTest do
     with_mock :hackney, context.es512.mocks do
       assert Guardian.decode_and_verify(context.es512.jwt_with_invalid_jku) == {:error, "unable to retrieve public key"}
     end
+  end
+
+  test "it verfies the jwt with jwk in header", context do
+    assert Guardian.decode_and_verify(context.es512.jwt_with_valid_jwk) == {:ok, context.claims}
   end
 
   test "it verifies the jwt with custom secret tuple", context do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -8,6 +8,22 @@ defmodule Guardian.TestGuardianSerializer do
   def from_token(aud), do: {:ok, aud}
 end
 
+defmodule Guardian.TestJKUAgent do
+  @moduledoc false
+
+  @behaviour Guardian.JKUAgent
+  def get(_kid, uri) do
+    with {:ok, 200, _headers, client} <- :hackney.request(:get, uri, [], "", []),
+         {:ok, body} <- :hackney.body(client),
+         {:ok, json} <- Poison.decode(body)
+    do
+      {:ok, JOSE.JWK.from_map(json)}
+    else
+      _err -> {:error, "unable to retrieve public key"}
+    end
+  end
+end
+
 defmodule Guardian.TestHelper do
   @moduledoc false
 


### PR DESCRIPTION
#### What does this PR do ?

* Adds support for JWK in header (https://tools.ietf.org/html/rfc7515#section-4.1.3)
* Fixes support for JKU in header (https://tools.ietf.org/html/rfc7515#section-4.1.2)
* Removed hardcoded use of hackney and define JKUAgent behaviour that's implemented at application level to fetch and cache keys.